### PR TITLE
rotating apikey validity is now in seconds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+test:
+	unset DJANGO_SETTINGS_MODULE; python manage.py test tastypiex
+

--- a/example/settings.py
+++ b/example/settings.py
@@ -15,7 +15,6 @@ from pathlib import Path
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
 
@@ -26,7 +25,6 @@ SECRET_KEY = 'django-insecure-q&ird0+x!=@9)iji)*@rm(p#50#$a5#4e)&j3&yl17(ekhb-f0
 DEBUG = True
 
 ALLOWED_HOSTS = []
-
 
 # Application definition
 
@@ -70,7 +68,6 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'example.wsgi.application'
 
-
 # Database
 # https://docs.djangoproject.com/en/3.2/ref/settings/#databases
 
@@ -80,7 +77,6 @@ DATABASES = {
         'NAME': BASE_DIR / 'db.sqlite3',
     }
 }
-
 
 # Password validation
 # https://docs.djangoproject.com/en/3.2/ref/settings/#auth-password-validators
@@ -100,7 +96,6 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-
 # Internationalization
 # https://docs.djangoproject.com/en/3.2/topics/i18n/
 
@@ -113,7 +108,6 @@ USE_I18N = True
 USE_L10N = True
 
 USE_TZ = True
-
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.2/howto/static-files/
@@ -128,8 +122,10 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 # use this to have PyCharm integration for Django tests
 try:
     import teamcity
+
     TEST_RUNNER = "teamcity.django.TeamcityDjangoRunner"
 except ModuleNotFoundError:
     pass
 
-TASTYPIE_APIKEY_DURATION = dict(years=99)
+TASTYPIE_APIKEY_DURATION = dict(weeks=52)
+TASTYPIE_APIKEY_PERMANENT = []

--- a/tastypiex/tests/test_tastypiex.py
+++ b/tastypiex/tests/test_tastypiex.py
@@ -1,16 +1,13 @@
+import os
 from datetime import timedelta
-
 from django.contrib.auth.models import User
+from django.test import TestCase
 from django.utils import timezone
 from tastypie.api import Api
 from tastypie.authentication import Authentication
 from tastypie.http import HttpUnauthorized
 from tastypie.resources import Resource
-
 from unittest.mock import patch, Mock
-
-import os
-from django.test import TestCase
 
 from tastypiex.centralize import ApiCentralizer
 from tastypiex.deferredauth import DeferredAuthentication
@@ -157,9 +154,10 @@ class TastypieXTestCases(TestCase):
         current_key = apikey.key
         auth = RotatingApiKeyAuthentication()
         # no limitation
-        future_dt = lambda: timezone.now() + timedelta(weeks=52 * 5)
-        self.assertTrue(auth.get_key(user, current_key))
-        self.assertTrue(auth.get_key(user, current_key, now=future_dt))
+        with self.settings(TASTYPIE_APIKEY_DURATION=0):
+            future_dt = lambda: timezone.now() + timedelta(weeks=52 * 5)
+            self.assertTrue(auth.get_key(user, current_key))
+            self.assertTrue(auth.get_key(user, current_key, now=future_dt))
         # test user exemption from apikey rotation
         with self.settings(TASTYPIE_APIKEY_DURATION={'days': 5},
                            TASTYPIE_APIKEY_PERMANENT=[user.username]):
@@ -216,9 +214,3 @@ class TastypieXTestCases(TestCase):
         self.assertEqual(seconds('1y'), timedelta(days=365).total_seconds())
         self.assertEqual(seconds(hours=5), timedelta(hours=5).total_seconds())
         self.assertEqual(seconds(days=365), timedelta(days=365).total_seconds())
-
-
-
-
-
-


### PR DESCRIPTION
- settings.TASTYPIE_APIKEY_DURATION is now in seconds by default
- use '<n>s|h|d|w|y' for seconds, hours, days, weeks, years